### PR TITLE
Fix marker positions

### DIFF
--- a/content/markers/01-shell.md
+++ b/content/markers/01-shell.md
@@ -3,7 +3,7 @@ title: "Shell"
 number: "1"
 position:
   left: "40%"
-  top: "65%"
+  top: "69%"
 description: "A gateway to controlling the system"
 date: 2025-02-13T12:00:00Z
 lastmod: 2025-02-13T12:00:00Z

--- a/content/markers/02-man.md
+++ b/content/markers/02-man.md
@@ -3,7 +3,7 @@ title: "man"
 number: "2"
 position:
   left: "15%"
-  top: "47%"
+  top: "51%"
 description: "Command to get detailed documentation of different unix components, including other cmds."
 ---
 

--- a/content/markers/03-pipes.md
+++ b/content/markers/03-pipes.md
@@ -3,7 +3,7 @@ title: "Pipes"
 number: "3"
 position:
   left: "45%"
-  top: "20%"
+  top: "24%"
 description: "Connect cmd outputs to cmd inputs to create complex pipelines"
 ---
 

--- a/content/markers/04-leak.md
+++ b/content/markers/04-leak.md
@@ -3,7 +3,7 @@ title: "Memory leaks"
 number: "4"
 position:
   left: "25%"
-  top: "25%"
+  top: "29%"
 description: "Improper managing of memory by a computer program"
 ---
 

--- a/content/markers/05-kandr.md
+++ b/content/markers/05-kandr.md
@@ -3,7 +3,7 @@ title: "Legendary figures"
 number: "5"
 position:
   left: "56%"
-  top: "25%"
+  top: "29%"
 description: "Legendary figures in Unix history"
 ---
 

--- a/content/markers/06-c.md
+++ b/content/markers/06-c.md
@@ -3,7 +3,7 @@ title: "The c programming language"
 number: "6"
 position:
   left: "89%"
-  top: "63%"
+  top: "67%"
 description: "A key programming language in the creation of Unix"
 ---
 

--- a/content/markers/07-backpressure.md
+++ b/content/markers/07-backpressure.md
@@ -3,7 +3,7 @@ title: "Backpressure"
 number: "7"
 position:
   left: "11%"
-  top: "18%"
+  top: "22%"
 description: "Tell producers to stop sending data because the consumer cannot keep up"
 ---
 

--- a/content/markers/08-daemons.md
+++ b/content/markers/08-daemons.md
@@ -3,7 +3,7 @@ title: "Daemons"
 number: "8"
 position:
   left: "66%"
-  top: "25%"
+  top: "29%"
 description: "Service processes that run in the background and supervise the system or provide functionality to other processes"
 ---
 

--- a/content/markers/09-su.md
+++ b/content/markers/09-su.md
@@ -3,7 +3,7 @@ title: "su"
 number: "9"
 position:
   left: "47%"
-  top: "26%"
+  top: "30%"
 description: "Command to switch your identity"
 ---
 

--- a/content/markers/10-null.md
+++ b/content/markers/10-null.md
@@ -3,7 +3,7 @@ title: "null"
 number: "10"
 position:
   left: "42.5%"
-  top: "79%"
+  top: "83%"
 description: "The null device is a device file that discards all data written to it but reports that the write operation succeeded."
 ---
 

--- a/content/markers/11-oregano.md
+++ b/content/markers/11-oregano.md
@@ -3,7 +3,7 @@ title: "Oregano"
 number: "11"
 position:
   left: "35%"
-  top: "84%"
+  top: "88%"
 description: "The Oregano incident"
 ---
 

--- a/content/markers/12-tar.md
+++ b/content/markers/12-tar.md
@@ -3,7 +3,7 @@ title: "tar"
 number: "12"
 position:
   left: "16%"
-  top: "81%"
+  top: "85%"
 description: "A software utility for collecting multiple files into a single archive file."
 ---
 

--- a/content/markers/13-fork.md
+++ b/content/markers/13-fork.md
@@ -3,7 +3,7 @@ title: "fork"
 number: "13"
 position:
   left: "25%"
-  top: "86%"
+  top: "90%"
 description: "An operation whereby a process creates a copy of itself"
 ---
 

--- a/content/markers/14-shell-script.md
+++ b/content/markers/14-shell-script.md
@@ -3,7 +3,7 @@ title: "Shell script"
 number: "14"
 position:
   left: "44.5%"
-  top: "86%"
+  top: "90%"
 description: "An operation whereby a process creates a copy of itself"
 ---
 

--- a/content/markers/15-awk.md
+++ b/content/markers/15-awk.md
@@ -3,7 +3,7 @@ title: "AWK"
 number: "15"
 position:
   left: "64.5%"
-  top: "85%"
+  top: "89%"
 description: "A language designed for text processing."
 ---
 

--- a/content/markers/16-usr.md
+++ b/content/markers/16-usr.md
@@ -3,7 +3,7 @@ title: "usr"
 number: "16"
 position:
   left: "67%"
-  top: "81.5%"
+  top: "85.5%"
 description: "A directory holding user home directories."
 ---
 

--- a/content/markers/17-troff.md
+++ b/content/markers/17-troff.md
@@ -3,7 +3,7 @@ title: "troff"
 number: "17"
 position:
   left: "70.5%"
-  top: "78%"
+  top: "82%"
 description: "A program in formatting documents for the document processing system."
 ---
 

--- a/content/markers/18-B.md
+++ b/content/markers/18-B.md
@@ -3,7 +3,7 @@ title: "B"
 number: "18"
 position:
   left: "80%"
-  top: "79%"
+  top: "83%"
 description: "An early programming language used in the early Multics project."
 ---
 

--- a/content/markers/19-cat.md
+++ b/content/markers/19-cat.md
@@ -3,7 +3,7 @@ title: "cat"
 number: "19"
 position:
   left: "89%"
-  top: "79%"
+  top: "83%"
 description: "A standard Unix utility that reads files sequentially, writing them to standard output."
 ---
 

--- a/content/markers/20-uucp.md
+++ b/content/markers/20-uucp.md
@@ -3,7 +3,7 @@ title: "uucp"
 number: "20"
 position:
   left: "77%"
-  top: "66%"
+  top: "69%"
 description: "A Unix program for file copy requests."
 ---
 

--- a/content/markers/21-socket.md
+++ b/content/markers/21-socket.md
@@ -3,7 +3,7 @@ title: "sockets"
 number: "21"
 position:
   left: "17%"
-  top: "56%"
+  top: "60%"
 description: "Networking sockets"
 ---
 

--- a/content/markers/22-make.md
+++ b/content/markers/22-make.md
@@ -1,0 +1,17 @@
+---
+title: "make"
+number: "22"
+position:
+  left: "83%"
+  top: "64%"
+description: "A software development tool to perform ordered actions and manage dependencies"
+---
+
+[Make](https://en.wikipedia.org/wiki/Make_(software)) is a command line interface
+that reads in a configuration `Makefile` that is often used in code executable
+compilation and automation.
+Before Make, building on Unix mostly consisted of shell scripts written for each program's codebase.
+Make's dependency ordering and out-of-date checking makes the build process more robust and more efficient.
+
+Stuart Feldman was the original author of Make, completing an early version in April 1976 at
+Bell Labs.

--- a/content/markers/23-spawn.md
+++ b/content/markers/23-spawn.md
@@ -1,0 +1,18 @@
+---
+title: "spawn"
+number: "23"
+position:
+  left: "66%"
+  top: "39%"
+description: "An operation in which a new child process is created"
+---
+
+Spawning is the process of loading and executing a new child process.
+Closely related is the idea of `fork` and `exec` that can be used
+to simulate spawning, by forking a process, having the parent terminate
+and `exec`ing the child into the desired spawn process.
+
+POSIX allow for the concept of spawning by itself that can be made
+to be more efficient than `fork` and `exec`.
+
+The spawn metaphor had its early use in the VMS operating system from 1977.

--- a/content/markers/24-jfo-nroff.md
+++ b/content/markers/24-jfo-nroff.md
@@ -1,0 +1,17 @@
+---
+title: "Jfo nroff"
+number: "24"
+position:
+  left: "76%"
+  top: "40%"
+description: "A text formatting program that produces fixed width output for printers and terminals"
+---
+
+`[nroff](https://en.wikipedia.org/wiki/Nroff)`, short for "new roff"
+is a text-formatting program produces output suitable for simple fixed-width
+printers and terminal windows.
+It is an integral part of the Unix help system, being used to format man pages for display.
+
+The letters *Jfo* stand for Joseph Frank Ossanna
+who created the original version of `nroff` for Version 2 Unix.
+

--- a/content/markers/25-root.md
+++ b/content/markers/25-root.md
@@ -1,0 +1,17 @@
+---
+title: "root"
+number: "25"
+position:
+  left: "89%"
+  top: "39%"
+description: "The administrator account on UNIX systems"
+---
+
+The root user is the name often given to the administrator or superuser account
+on UNIX systems.
+In Unix-like systems, root is the conventional name of the user who has all rights or
+permissions to all files and programs in all modes (e.g. single- or multi-user). 
+The root user can do many things an ordinary user cannot, such as changing the
+ownership of files and binding to network ports numbered below 1024.
+
+

--- a/content/markers/26-dates.md
+++ b/content/markers/26-dates.md
@@ -1,0 +1,21 @@
+---
+title: "dates"
+number: "26"
+position:
+  left: "84%"
+  top: "46%"
+description: "A command to display and set the system date"
+---
+
+`date` is a command to display and set a UNIX system date.
+
+Unix time is currently defined as the number of non-leap seconds which have passed since 00:00:00 UTC on Thursday, 1 January 1970,
+which is referred to as the Unix epoch.
+
+The earliest versions of Unix time had a 32-bit integer incrementing at a rate of 60 Hz, which was the rate of the system clock
+on the hardware of the early Unix systems.
+Timestamps stored this way could only represent a range of a little over two and a quarter years.
+
+The current epoch of 1 January 1970 00:00:00 UTC was selected arbitrarily by Unix engineers because it was considered a
+convenient date to work with.
+

--- a/content/markers/27-whoami.md
+++ b/content/markers/27-whoami.md
@@ -1,0 +1,16 @@
+---
+title: "whoami"
+number: "27"
+position:
+  left: "71%"
+  top: "26%"
+description: "A command to provide the effective username of the current user"
+---
+
+Users on UNIX systems may want to 
+switch to other accounts, allowing for switching roles, escalation or deescalation of
+privileges or might be logging into multiple machines across networks.
+The [`whoami`](https://en.wikipedia.org/wiki/Whoami) is a command to tell the invoker
+what user they are logged in as.
+
+The earliest versions were created in 2.9 BSD.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -214,7 +214,7 @@
     </div>
 
 
-    <div class="image-container">
+    <div class="image-container" id='poster-container'>
         <!-- to avoid formatting issues -->
         {{ $image := "ump.webp" }}
         <img id="poster" src="{{ $image | relURL }}" alt="Unix Magic Poster">
@@ -267,6 +267,7 @@
 
     <script>
         function positionMarkers() {
+            const imgContainer = document.getElementById('poster-container');
             const poster = document.getElementById('poster');
             const markers = document.querySelectorAll('.marker');
 
@@ -275,18 +276,20 @@
                 return;
             }
 
+            const rectContainer = imgContainer.getBoundingClientRect();
             const rect = poster.getBoundingClientRect();
 
             markers.forEach(marker => {
                 const leftPercent = parseFloat(marker.getAttribute("data-left"));
                 const topPercent = parseFloat(marker.getAttribute("data-top"));
 
-                marker.style.left = `${(leftPercent / 100) * rect.width + rect.left}px`;
-                marker.style.top = `${(topPercent / 100) * rect.height + rect.top}px`;
+                marker.style.left = `${(leftPercent / 100) * rect.width + rect.left - rectContainer.left}px`;
+                marker.style.top = `${(topPercent / 100) * rect.height + rect.top - rectContainer.top}px`;
             });
         }
 
         document.addEventListener('DOMContentLoaded', function () {
+
             positionMarkers();
 
             window.addEventListener('resize', positionMarkers);


### PR DESCRIPTION
Markers are positioned relative to the image-container that the `poster` element
sits in but `positionMarkers` was assuming things were relative to
the `poster` element, causing issues on resizing, reloading when
the page is partially scrolled down and various other scenarios.

To fix, markers are now repositioned relative to the `image-container`
element, taking into account the poster left and top.

Under normal circumstances, the header (currently the header line with
github, rss and 'about' in it) is pretty stable, so positioning the
marker percentages enough to eyeball it without issue, which is why
it probably didn't get noticed.

A simple test is to create a test marker at (50%,50%) and see if it
really sits in the middle of the poster.

Marker positions have been shifted by 4% lower to reflect the offset now
introduced from the fix.
