### PR TITLE
spelling

### DIFF
--- a/content/markers/39-skull.md
+++ b/content/markers/39-skull.md
@@ -1,5 +1,5 @@
 ---
-title: "shull"
+title: "skull"
 number: "39"
 position:
   left: "50%"


### PR DESCRIPTION
single character fix.

"todo" is still there.

Probably not worth making a whole issue about it but some things to consider:

* to me, this doesn't look like a skull but more like a gargoyle (or maybe even a monkey?). This might indicate that it's referencing daemons
* the top of head has an old time faucet handle and this might be referencing IO redirection ([streams](https://en.wikipedia.org/wiki/Standard_streams)). Note that my initial thought that it might be referencing `tun/tap` is completely off base because that didn't come until 2000 or later ([tun/tap](https://en.wikipedia.org/wiki/TUN/TAP))